### PR TITLE
feat: Implement Users/Groups

### DIFF
--- a/models/group.go
+++ b/models/group.go
@@ -1,0 +1,12 @@
+package models
+
+import "time"
+
+// Group represents a user group.
+type Group struct {
+	ID        string    `json:"id"`
+	CreatedAt time.Time `json:"createdAt"`
+	Name      string    `json:"name"`
+	OwnerID   string    `json:"ownerId"`
+	UserIDs   []string  `json:"userIds"`
+}

--- a/models/group.go
+++ b/models/group.go
@@ -10,3 +10,9 @@ type Group struct {
 	OwnerID   string    `json:"ownerId"`
 	UserIDs   []string  `json:"userIds"`
 }
+
+// GroupInvitation represents a group invitation.
+type GroupInvitation struct {
+	ID    string `json:"id"`
+	Group Group  `json:"group"`
+}

--- a/services.go
+++ b/services.go
@@ -13,6 +13,7 @@ import (
 	"github.com/yitsushi/go-misskey/services/notes"
 	"github.com/yitsushi/go-misskey/services/notifications"
 	"github.com/yitsushi/go-misskey/services/promo"
+	"github.com/yitsushi/go-misskey/services/users"
 )
 
 func (c *Client) requestHandler(request core.Request, response interface{}) error {
@@ -77,4 +78,9 @@ func (c *Client) Admin() *admin.Service {
 // Following contains all endpoints under /following.
 func (c *Client) Following() *following.Service {
 	return following.NewService(c.requestHandler)
+}
+
+// Users contains all endpoints under /users.
+func (c *Client) Users() *users.Service {
+	return users.NewService(c.requestHandler)
 }

--- a/services/admin/announcements/create_test.go
+++ b/services/admin/announcements/create_test.go
@@ -21,7 +21,7 @@ func TestService_Create(t *testing.T) {
 		StatusCode:   http.StatusOK,
 	})
 
-	response, err := client.Admin().Accouncements().Create(announcements.CreateRequest{
+	response, err := client.Admin().Announcements().Create(announcements.CreateRequest{
 		Title: "title",
 		Text:  "text",
 	})
@@ -61,7 +61,7 @@ func TestCreateRequest_Validate(t *testing.T) {
 func ExampleService_Create() {
 	client := misskey.NewClient("https://slippy.xyz", os.Getenv("MISSKEY_TOKEN"))
 
-	response, err := client.Admin().Accouncements().Create(announcements.CreateRequest{
+	response, err := client.Admin().Announcements().Create(announcements.CreateRequest{
 		Title: "New Announcement",
 		Text:  "Because we can do it!",
 	})

--- a/services/admin/announcements/delete_test.go
+++ b/services/admin/announcements/delete_test.go
@@ -21,7 +21,7 @@ func TestService_Delete(t *testing.T) {
 		StatusCode:   http.StatusNoContent,
 	})
 
-	err := client.Admin().Accouncements().Delete("8d44utwtj6")
+	err := client.Admin().Announcements().Delete("8d44utwtj6")
 
 	assert.NoError(t, err)
 }
@@ -42,7 +42,7 @@ func TestDeleteRequest_Validate(t *testing.T) {
 func ExampleService_Delete() {
 	client := misskey.NewClient("https://slippy.xyz", os.Getenv("MISSKEY_TOKEN"))
 
-	err := client.Admin().Accouncements().Delete("8d44utwtj6")
+	err := client.Admin().Announcements().Delete("8d44utwtj6")
 	if err != nil {
 		log.Printf("[Admin/Announcements] %s", err)
 

--- a/services/admin/announcements/list_test.go
+++ b/services/admin/announcements/list_test.go
@@ -21,7 +21,7 @@ func TestService_List(t *testing.T) {
 		StatusCode:   http.StatusOK,
 	})
 
-	response, err := client.Admin().Accouncements().List(announcements.ListRequest{
+	response, err := client.Admin().Announcements().List(announcements.ListRequest{
 		Limit: 1,
 	})
 	if !assert.NoError(t, err) {
@@ -47,7 +47,7 @@ func TestListRequest_Validate(t *testing.T) {
 func ExampleService_List() {
 	client := misskey.NewClient("https://slippy.xyz", os.Getenv("MISSKEY_TOKEN"))
 
-	response, err := client.Admin().Accouncements().List(announcements.ListRequest{
+	response, err := client.Admin().Announcements().List(announcements.ListRequest{
 		Limit: 10,
 	})
 	if err != nil {

--- a/services/admin/announcements/update_test.go
+++ b/services/admin/announcements/update_test.go
@@ -21,7 +21,7 @@ func TestService_Update(t *testing.T) {
 		StatusCode:   http.StatusNoContent,
 	})
 
-	err := client.Admin().Accouncements().Update(announcements.UpdateRequest{
+	err := client.Admin().Announcements().Update(announcements.UpdateRequest{
 		ID:    "8d44utwtj6",
 		Title: "New Title",
 		Text:  "New text",
@@ -63,7 +63,7 @@ func TestUpdateRequest_Validate(t *testing.T) {
 func ExampleService_Update() {
 	client := misskey.NewClient("https://slippy.xyz", os.Getenv("MISSKEY_TOKEN"))
 
-	err := client.Admin().Accouncements().Update(announcements.UpdateRequest{
+	err := client.Admin().Announcements().Update(announcements.UpdateRequest{
 		ID:    "8d44utwtj6",
 		Title: "New Title",
 		Text:  "New text",

--- a/services/admin/service.go
+++ b/services/admin/service.go
@@ -24,8 +24,8 @@ func NewService(requestHandler core.RequestHandlerFunc) *Service {
 	return &Service{Call: requestHandler}
 }
 
-// Accouncements contains all endpoints under /admin/announcements.
-func (s *Service) Accouncements() *announcements.Service {
+// Announcements contains all endpoints under /admin/announcements.
+func (s *Service) Announcements() *announcements.Service {
 	return announcements.NewService(s.Call)
 }
 

--- a/services/users/groups/create.go
+++ b/services/users/groups/create.go
@@ -1,0 +1,36 @@
+package groups
+
+import (
+	"github.com/yitsushi/go-misskey/core"
+	"github.com/yitsushi/go-misskey/models"
+)
+
+// CreateRequest represents an Create request.
+type CreateRequest struct {
+	Name string `json:"name"`
+}
+
+// Validate the request.
+func (r CreateRequest) Validate() error {
+	if r.Name == "" {
+		return core.RequestValidationError{
+			Request: r,
+			Message: core.UndefinedRequiredField,
+			Field:   "Name",
+		}
+	}
+
+	return nil
+}
+
+// Create group.
+func (s *Service) Create(name string) (models.Group, error) {
+	request := CreateRequest{Name: name}
+	response := models.Group{}
+	err := s.Call(
+		&core.JSONRequest{Request: &request, Path: "/users/groups/create"},
+		&response,
+	)
+
+	return response, err
+}

--- a/services/users/groups/create_test.go
+++ b/services/users/groups/create_test.go
@@ -1,0 +1,55 @@
+package groups_test
+
+import (
+	"log"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/yitsushi/go-misskey"
+	"github.com/yitsushi/go-misskey/core"
+	"github.com/yitsushi/go-misskey/services/users/groups"
+	"github.com/yitsushi/go-misskey/test"
+)
+
+func TestService_Create(t *testing.T) {
+	client := test.MakeMockClient(test.SimpleMockOptions{
+		Endpoint:     "/api/users/groups/create",
+		RequestData:  &groups.CreateRequest{},
+		ResponseFile: "show.json",
+		StatusCode:   http.StatusOK,
+	})
+
+	group, err := client.Users().Groups().Create("Test")
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Equal(t, "Test", group.Name)
+}
+
+func TestCreateRequest_Validate(t *testing.T) {
+	test.ValidateRequests(
+		t,
+		[]core.BaseRequest{
+			groups.CreateRequest{},
+		},
+		[]core.BaseRequest{
+			groups.CreateRequest{Name: "Test"},
+		},
+	)
+}
+
+func ExampleService_Create() {
+	client := misskey.NewClient("https://slippy.xyz", os.Getenv("MISSKEY_TOKEN"))
+
+	group, err := client.Users().Groups().Create("Test")
+	if err != nil {
+		log.Printf("[Users/Groups/Create] %s", err)
+
+		return
+	}
+
+	log.Printf("[Users/Groups/Create] %s", group.Name)
+}

--- a/services/users/groups/delete.go
+++ b/services/users/groups/delete.go
@@ -1,0 +1,34 @@
+package groups
+
+import (
+	"github.com/yitsushi/go-misskey/core"
+)
+
+// DeleteRequest represents an Delete request.
+type DeleteRequest struct {
+	GroupID string `json:"groupId"`
+}
+
+// Validate the request.
+func (r DeleteRequest) Validate() error {
+	if r.GroupID == "" {
+		return core.RequestValidationError{
+			Request: r,
+			Message: core.UndefinedRequiredField,
+			Field:   "GroupID",
+		}
+	}
+
+	return nil
+}
+
+// Delete group.
+func (s *Service) Delete(groupID string) error {
+	request := DeleteRequest{GroupID: groupID}
+	err := s.Call(
+		&core.JSONRequest{Request: &request, Path: "/users/groups/delete"},
+		&core.EmptyResponse{},
+	)
+
+	return err
+}

--- a/services/users/groups/delete_test.go
+++ b/services/users/groups/delete_test.go
@@ -1,0 +1,51 @@
+package groups_test
+
+import (
+	"log"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/yitsushi/go-misskey"
+	"github.com/yitsushi/go-misskey/core"
+	"github.com/yitsushi/go-misskey/services/users/groups"
+	"github.com/yitsushi/go-misskey/test"
+)
+
+func TestService_Delete(t *testing.T) {
+	client := test.MakeMockClient(test.SimpleMockOptions{
+		Endpoint:     "/api/users/groups/delete",
+		RequestData:  &groups.DeleteRequest{},
+		ResponseFile: "empty",
+		StatusCode:   http.StatusNoContent,
+	})
+
+	err := client.Users().Groups().Delete("8y4nlhyx3v")
+	if !assert.NoError(t, err) {
+		return
+	}
+}
+
+func TestDeleteRequest_Validate(t *testing.T) {
+	test.ValidateRequests(
+		t,
+		[]core.BaseRequest{
+			groups.DeleteRequest{},
+		},
+		[]core.BaseRequest{
+			groups.DeleteRequest{GroupID: "8y4nlhyx3v"},
+		},
+	)
+}
+
+func ExampleService_Delete() {
+	client := misskey.NewClient("https://slippy.xyz", os.Getenv("MISSKEY_TOKEN"))
+
+	err := client.Users().Groups().Delete("8y4nlhyx3v")
+	if err != nil {
+		log.Printf("[Users/Groups/Delete] %s", err)
+
+		return
+	}
+}

--- a/services/users/groups/fixtures/joined.json
+++ b/services/users/groups/fixtures/joined.json
@@ -1,0 +1,11 @@
+[
+  {
+    "createdAt": "2020-02-16T18:57:39.746Z",
+    "id": "93tyd132e7",
+    "name": "Test",
+    "ownerId": "83sv4lyx22",
+    "userIds": [
+      "83sv4lyx22"
+    ]
+  }
+]

--- a/services/users/groups/fixtures/owned.json
+++ b/services/users/groups/fixtures/owned.json
@@ -1,0 +1,11 @@
+[
+  {
+    "createdAt": "2020-02-16T18:57:39.746Z",
+    "id": "93tyd132e7",
+    "name": "Admin",
+    "ownerId": "83sv4lyx22",
+    "userIds": [
+      "83sv4lyx22"
+    ]
+  }
+]

--- a/services/users/groups/fixtures/show.json
+++ b/services/users/groups/fixtures/show.json
@@ -1,0 +1,9 @@
+{
+  "createdAt": "2020-02-16T18:57:39.746Z",
+  "id": "93tyd132e7",
+  "name": "Test",
+  "ownerId": "83sv4lyx22",
+  "userIds": [
+    "83sv4lyx22"
+  ]
+}

--- a/services/users/groups/invitations/accept.go
+++ b/services/users/groups/invitations/accept.go
@@ -1,0 +1,34 @@
+package invitations
+
+import (
+	"github.com/yitsushi/go-misskey/core"
+)
+
+// AcceptRequest represents an Accept request.
+type AcceptRequest struct {
+	InvitationID string `json:"invitationId"`
+}
+
+// Validate the request.
+func (r AcceptRequest) Validate() error {
+	if r.InvitationID == "" {
+		return core.RequestValidationError{
+			Request: r,
+			Message: core.UndefinedRequiredField,
+			Field:   "InvitationID",
+		}
+	}
+
+	return nil
+}
+
+// Accept group.
+func (s *Service) Accept(invitationID string) error {
+	request := AcceptRequest{InvitationID: invitationID}
+	err := s.Call(
+		&core.JSONRequest{Request: &request, Path: "/users/groups/invitations/accept"},
+		&core.EmptyResponse{},
+	)
+
+	return err
+}

--- a/services/users/groups/invitations/accept_test.go
+++ b/services/users/groups/invitations/accept_test.go
@@ -1,0 +1,51 @@
+package invitations_test
+
+import (
+	"log"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/yitsushi/go-misskey"
+	"github.com/yitsushi/go-misskey/core"
+	"github.com/yitsushi/go-misskey/services/users/groups/invitations"
+	"github.com/yitsushi/go-misskey/test"
+)
+
+func TestService_Accept(t *testing.T) {
+	client := test.MakeMockClient(test.SimpleMockOptions{
+		Endpoint:     "/api/users/groups/invitations/accept",
+		RequestData:  &invitations.AcceptRequest{},
+		ResponseFile: "empty",
+		StatusCode:   http.StatusNoContent,
+	})
+
+	err := client.Users().Groups().Invitations().Accept("8y4nwgla5f")
+	if !assert.NoError(t, err) {
+		return
+	}
+}
+
+func TestAcceptRequest_Validate(t *testing.T) {
+	test.ValidateRequests(
+		t,
+		[]core.BaseRequest{
+			invitations.AcceptRequest{},
+		},
+		[]core.BaseRequest{
+			invitations.AcceptRequest{InvitationID: "8y4nwgla5f"},
+		},
+	)
+}
+
+func ExampleService_Accept() {
+	client := misskey.NewClient("https://slippy.xyz", os.Getenv("MISSKEY_TOKEN"))
+
+	err := client.Users().Groups().Invitations().Accept("8y4nwgla5f")
+	if err != nil {
+		log.Printf("[Users/Groups/Invitations/Accept] %s", err)
+
+		return
+	}
+}

--- a/services/users/groups/invitations/fixtures/list.json
+++ b/services/users/groups/invitations/fixtures/list.json
@@ -1,0 +1,14 @@
+[
+  {
+    "group": {
+      "createdAt": "2022-03-21T19:25:14.500Z",
+      "id": "8y4nwadg5d",
+      "name": "Another Test",
+      "ownerId": "88v9vu5nbu",
+      "userIds": [
+        "88v9vu5nbu"
+      ]
+    },
+    "id": "8y4nwgla5f"
+  }
+]

--- a/services/users/groups/invitations/list.go
+++ b/services/users/groups/invitations/list.go
@@ -1,0 +1,29 @@
+package invitations
+
+import (
+	"github.com/yitsushi/go-misskey/core"
+	"github.com/yitsushi/go-misskey/models"
+)
+
+// ListRequest represents an List request.
+type ListRequest struct {
+	Limit   int    `json:"limit,omitempty"`
+	SinceID string `json:"sinceId,omitempty"`
+	UntilID string `json:"untilId,omitempty"`
+}
+
+// Validate the request.
+func (r ListRequest) Validate() error {
+	return nil
+}
+
+// List group.
+func (s *Service) List(request ListRequest) ([]models.GroupInvitation, error) {
+	response := []models.GroupInvitation{}
+	err := s.Call(
+		&core.JSONRequest{Request: &request, Path: "/i/user-group-invites"},
+		&response,
+	)
+
+	return response, err
+}

--- a/services/users/groups/invitations/list_test.go
+++ b/services/users/groups/invitations/list_test.go
@@ -1,0 +1,55 @@
+package invitations_test
+
+import (
+	"log"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/yitsushi/go-misskey"
+	"github.com/yitsushi/go-misskey/core"
+	"github.com/yitsushi/go-misskey/services/users/groups/invitations"
+	"github.com/yitsushi/go-misskey/test"
+)
+
+func TestService_List(t *testing.T) {
+	client := test.MakeMockClient(test.SimpleMockOptions{
+		Endpoint:     "/api/i/user-group-invites",
+		RequestData:  &invitations.ListRequest{},
+		ResponseFile: "list.json",
+		StatusCode:   http.StatusOK,
+	})
+
+	invs, err := client.Users().Groups().Invitations().List(invitations.ListRequest{})
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Len(t, invs, 1)
+}
+
+func TestListRequest_Validate(t *testing.T) {
+	test.ValidateRequests(
+		t,
+		[]core.BaseRequest{},
+		[]core.BaseRequest{
+			invitations.ListRequest{},
+		},
+	)
+}
+
+func ExampleService_List() {
+	client := misskey.NewClient("https://slippy.xyz", os.Getenv("MISSKEY_TOKEN"))
+
+	invs, err := client.Users().Groups().Invitations().List(invitations.ListRequest{})
+	if err != nil {
+		log.Printf("[Users/Groups/Invitations/List] %s", err)
+
+		return
+	}
+
+	for _, inv := range invs {
+		log.Printf("[Users/Groups/Invitations/List] <%s> %s", inv.ID, inv.Group.Name)
+	}
+}

--- a/services/users/groups/invitations/reject.go
+++ b/services/users/groups/invitations/reject.go
@@ -1,0 +1,34 @@
+package invitations
+
+import (
+	"github.com/yitsushi/go-misskey/core"
+)
+
+// RejectRequest represents an Reject request.
+type RejectRequest struct {
+	InvitationID string `json:"invitationId"`
+}
+
+// Validate the request.
+func (r RejectRequest) Validate() error {
+	if r.InvitationID == "" {
+		return core.RequestValidationError{
+			Request: r,
+			Message: core.UndefinedRequiredField,
+			Field:   "InvitationID",
+		}
+	}
+
+	return nil
+}
+
+// Reject group.
+func (s *Service) Reject(invitationID string) error {
+	request := RejectRequest{InvitationID: invitationID}
+	err := s.Call(
+		&core.JSONRequest{Request: &request, Path: "/users/groups/invitations/reject"},
+		&core.EmptyResponse{},
+	)
+
+	return err
+}

--- a/services/users/groups/invitations/reject_test.go
+++ b/services/users/groups/invitations/reject_test.go
@@ -1,0 +1,51 @@
+package invitations_test
+
+import (
+	"log"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/yitsushi/go-misskey"
+	"github.com/yitsushi/go-misskey/core"
+	"github.com/yitsushi/go-misskey/services/users/groups/invitations"
+	"github.com/yitsushi/go-misskey/test"
+)
+
+func TestService_Reject(t *testing.T) {
+	client := test.MakeMockClient(test.SimpleMockOptions{
+		Endpoint:     "/api/users/groups/invitations/reject",
+		RequestData:  &invitations.RejectRequest{},
+		ResponseFile: "empty",
+		StatusCode:   http.StatusNoContent,
+	})
+
+	err := client.Users().Groups().Invitations().Reject("8y4nwgla5f")
+	if !assert.NoError(t, err) {
+		return
+	}
+}
+
+func TestRejectRequest_Validate(t *testing.T) {
+	test.ValidateRequests(
+		t,
+		[]core.BaseRequest{
+			invitations.RejectRequest{},
+		},
+		[]core.BaseRequest{
+			invitations.RejectRequest{InvitationID: "8y4nwgla5f"},
+		},
+	)
+}
+
+func ExampleService_Reject() {
+	client := misskey.NewClient("https://slippy.xyz", os.Getenv("MISSKEY_TOKEN"))
+
+	err := client.Users().Groups().Invitations().Reject("8y4nwgla5f")
+	if err != nil {
+		log.Printf("[Users/Groups/Invitations/Reject] %s", err)
+
+		return
+	}
+}

--- a/services/users/groups/invitations/service.go
+++ b/services/users/groups/invitations/service.go
@@ -1,8 +1,7 @@
-package groups
+package invitations
 
 import (
 	"github.com/yitsushi/go-misskey/core"
-	"github.com/yitsushi/go-misskey/services/users/groups/invitations"
 )
 
 // Service is the base for all the endpoints on this service.
@@ -13,9 +12,4 @@ type Service struct {
 // NewService creates a new Service instance.
 func NewService(requestHandler core.RequestHandlerFunc) *Service {
 	return &Service{Call: requestHandler}
-}
-
-// Invitations contains all endpoints about group invitations.
-func (s *Service) Invitations() *invitations.Service {
-	return invitations.NewService(s.Call)
 }

--- a/services/users/groups/invite.go
+++ b/services/users/groups/invite.go
@@ -1,0 +1,43 @@
+package groups
+
+import (
+	"github.com/yitsushi/go-misskey/core"
+)
+
+// InviteRequest represents an Invite request.
+type InviteRequest struct {
+	GroupID string `json:"groupId"`
+	UserID  string `json:"userId"`
+}
+
+// Validate the request.
+func (r InviteRequest) Validate() error {
+	if r.GroupID == "" {
+		return core.RequestValidationError{
+			Request: r,
+			Message: core.UndefinedRequiredField,
+			Field:   "GroupID",
+		}
+	}
+
+	if r.UserID == "" {
+		return core.RequestValidationError{
+			Request: r,
+			Message: core.UndefinedRequiredField,
+			Field:   "UserID",
+		}
+	}
+
+	return nil
+}
+
+// Invite group.
+func (s *Service) Invite(groupID, userID string) error {
+	request := InviteRequest{GroupID: groupID, UserID: userID}
+	err := s.Call(
+		&core.JSONRequest{Request: &request, Path: "/users/groups/invite"},
+		&core.EmptyResponse{},
+	)
+
+	return err
+}

--- a/services/users/groups/invite_test.go
+++ b/services/users/groups/invite_test.go
@@ -1,0 +1,53 @@
+package groups_test
+
+import (
+	"log"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/yitsushi/go-misskey"
+	"github.com/yitsushi/go-misskey/core"
+	"github.com/yitsushi/go-misskey/services/users/groups"
+	"github.com/yitsushi/go-misskey/test"
+)
+
+func TestService_Invite(t *testing.T) {
+	client := test.MakeMockClient(test.SimpleMockOptions{
+		Endpoint:     "/api/users/groups/invite",
+		RequestData:  &groups.InviteRequest{},
+		ResponseFile: "empty",
+		StatusCode:   http.StatusNoContent,
+	})
+
+	err := client.Users().Groups().Invite("93tyd132e7", "83sv4lyx22")
+	if !assert.NoError(t, err) {
+		return
+	}
+}
+
+func TestInviteRequest_Validate(t *testing.T) {
+	test.ValidateRequests(
+		t,
+		[]core.BaseRequest{
+			groups.InviteRequest{},
+			groups.InviteRequest{GroupID: "93tyd132e7"},
+			groups.InviteRequest{UserID: "93tyd132e7"},
+		},
+		[]core.BaseRequest{
+			groups.InviteRequest{GroupID: "93tyd132e7", UserID: "83sv4lyx22"},
+		},
+	)
+}
+
+func ExampleService_Invite() {
+	client := misskey.NewClient("https://slippy.xyz", os.Getenv("MISSKEY_TOKEN"))
+
+	err := client.Users().Groups().Invite("93tyd132e7", "83sv4lyx22")
+	if err != nil {
+		log.Printf("[Users/Groups/Invite] %s", err)
+
+		return
+	}
+}

--- a/services/users/groups/joined.go
+++ b/services/users/groups/joined.go
@@ -1,0 +1,25 @@
+package groups
+
+import (
+	"github.com/yitsushi/go-misskey/core"
+	"github.com/yitsushi/go-misskey/models"
+)
+
+// JoinedRequest represents an List request.
+type JoinedRequest struct{}
+
+// Validate the request.
+func (r JoinedRequest) Validate() error {
+	return nil
+}
+
+// Joined clips.
+func (s *Service) Joined() ([]models.Group, error) {
+	var response []models.Group
+	err := s.Call(
+		&core.JSONRequest{Request: &JoinedRequest{}, Path: "/users/groups/joined"},
+		&response,
+	)
+
+	return response, err
+}

--- a/services/users/groups/joined_test.go
+++ b/services/users/groups/joined_test.go
@@ -1,0 +1,43 @@
+package groups_test
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/yitsushi/go-misskey"
+	"github.com/yitsushi/go-misskey/services/users/groups"
+	"github.com/yitsushi/go-misskey/test"
+	"log"
+	"net/http"
+	"os"
+	"testing"
+)
+
+func TestService_Joined(t *testing.T) {
+	client := test.MakeMockClient(test.SimpleMockOptions{
+		Endpoint:     "/api/users/groups/joined",
+		RequestData:  &groups.JoinedRequest{},
+		ResponseFile: "joined.json",
+		StatusCode:   http.StatusOK,
+	})
+
+	resp, err := client.Users().Groups().Joined()
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Len(t, resp, 1)
+}
+
+func ExampleService_Joined() {
+	client := misskey.NewClient("https://slippy.xyz", os.Getenv("MISSKEY_TOKEN"))
+
+	resp, err := client.Users().Groups().Joined()
+	if err != nil {
+		log.Printf("[Users/Groups/Joined] %s", err)
+
+		return
+	}
+
+	for _, group := range resp {
+		log.Printf("[Users/Groups/Joined] %s", group.Name)
+	}
+}

--- a/services/users/groups/joined_test.go
+++ b/services/users/groups/joined_test.go
@@ -1,14 +1,15 @@
 package groups_test
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/yitsushi/go-misskey"
-	"github.com/yitsushi/go-misskey/services/users/groups"
-	"github.com/yitsushi/go-misskey/test"
 	"log"
 	"net/http"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/yitsushi/go-misskey"
+	"github.com/yitsushi/go-misskey/services/users/groups"
+	"github.com/yitsushi/go-misskey/test"
 )
 
 func TestService_Joined(t *testing.T) {

--- a/services/users/groups/kick.go
+++ b/services/users/groups/kick.go
@@ -1,0 +1,43 @@
+package groups
+
+import (
+	"github.com/yitsushi/go-misskey/core"
+)
+
+// KickRequest represents an Kick request.
+type KickRequest struct {
+	GroupID string `json:"groupId"`
+	UserID  string `json:"userId"`
+}
+
+// Validate the request.
+func (r KickRequest) Validate() error {
+	if r.GroupID == "" {
+		return core.RequestValidationError{
+			Request: r,
+			Message: core.UndefinedRequiredField,
+			Field:   "GroupID",
+		}
+	}
+
+	if r.UserID == "" {
+		return core.RequestValidationError{
+			Request: r,
+			Message: core.UndefinedRequiredField,
+			Field:   "UserID",
+		}
+	}
+
+	return nil
+}
+
+// Kick group.
+func (s *Service) Kick(groupID, userID string) error {
+	request := KickRequest{GroupID: groupID, UserID: userID}
+	err := s.Call(
+		&core.JSONRequest{Request: &request, Path: "/users/groups/pull"},
+		&core.EmptyResponse{},
+	)
+
+	return err
+}

--- a/services/users/groups/kick_test.go
+++ b/services/users/groups/kick_test.go
@@ -1,0 +1,53 @@
+package groups_test
+
+import (
+	"log"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/yitsushi/go-misskey"
+	"github.com/yitsushi/go-misskey/core"
+	"github.com/yitsushi/go-misskey/services/users/groups"
+	"github.com/yitsushi/go-misskey/test"
+)
+
+func TestService_Kick(t *testing.T) {
+	client := test.MakeMockClient(test.SimpleMockOptions{
+		Endpoint:     "/api/users/groups/pull",
+		RequestData:  &groups.KickRequest{},
+		ResponseFile: "empty",
+		StatusCode:   http.StatusNoContent,
+	})
+
+	err := client.Users().Groups().Kick("93tyd132e7", "83sv4lyx22")
+	if !assert.NoError(t, err) {
+		return
+	}
+}
+
+func TestKickRequest_Validate(t *testing.T) {
+	test.ValidateRequests(
+		t,
+		[]core.BaseRequest{
+			groups.KickRequest{},
+			groups.KickRequest{GroupID: "93tyd132e7"},
+			groups.KickRequest{UserID: "93tyd132e7"},
+		},
+		[]core.BaseRequest{
+			groups.KickRequest{GroupID: "93tyd132e7", UserID: "83sv4lyx22"},
+		},
+	)
+}
+
+func ExampleService_Kick() {
+	client := misskey.NewClient("https://slippy.xyz", os.Getenv("MISSKEY_TOKEN"))
+
+	err := client.Users().Groups().Kick("93tyd132e7", "83sv4lyx22")
+	if err != nil {
+		log.Printf("[Users/Groups/Kick] %s", err)
+
+		return
+	}
+}

--- a/services/users/groups/leave.go
+++ b/services/users/groups/leave.go
@@ -1,0 +1,34 @@
+package groups
+
+import (
+	"github.com/yitsushi/go-misskey/core"
+)
+
+// LeaveRequest represents an Leave request.
+type LeaveRequest struct {
+	GroupID string `json:"groupId"`
+}
+
+// Validate the request.
+func (r LeaveRequest) Validate() error {
+	if r.GroupID == "" {
+		return core.RequestValidationError{
+			Request: r,
+			Message: core.UndefinedRequiredField,
+			Field:   "GroupID",
+		}
+	}
+
+	return nil
+}
+
+// Leave group.
+func (s *Service) Leave(groupID string) error {
+	request := LeaveRequest{GroupID: groupID}
+	err := s.Call(
+		&core.JSONRequest{Request: &request, Path: "/users/groups/leave"},
+		&core.EmptyResponse{},
+	)
+
+	return err
+}

--- a/services/users/groups/leave_test.go
+++ b/services/users/groups/leave_test.go
@@ -1,0 +1,51 @@
+package groups_test
+
+import (
+	"log"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/yitsushi/go-misskey"
+	"github.com/yitsushi/go-misskey/core"
+	"github.com/yitsushi/go-misskey/services/users/groups"
+	"github.com/yitsushi/go-misskey/test"
+)
+
+func TestService_Leave(t *testing.T) {
+	client := test.MakeMockClient(test.SimpleMockOptions{
+		Endpoint:     "/api/users/groups/leave",
+		RequestData:  &groups.LeaveRequest{},
+		ResponseFile: "empty",
+		StatusCode:   http.StatusNoContent,
+	})
+
+	err := client.Users().Groups().Leave("93tyd132e7")
+	if !assert.NoError(t, err) {
+		return
+	}
+}
+
+func TestLeaveRequest_Validate(t *testing.T) {
+	test.ValidateRequests(
+		t,
+		[]core.BaseRequest{
+			groups.LeaveRequest{},
+		},
+		[]core.BaseRequest{
+			groups.LeaveRequest{GroupID: "93tyd132e7"},
+		},
+	)
+}
+
+func ExampleService_Leave() {
+	client := misskey.NewClient("https://slippy.xyz", os.Getenv("MISSKEY_TOKEN"))
+
+	err := client.Users().Groups().Leave("93tyd132e7")
+	if err != nil {
+		log.Printf("[Users/Groups/Leave] %s", err)
+
+		return
+	}
+}

--- a/services/users/groups/owned.go
+++ b/services/users/groups/owned.go
@@ -1,0 +1,25 @@
+package groups
+
+import (
+	"github.com/yitsushi/go-misskey/core"
+	"github.com/yitsushi/go-misskey/models"
+)
+
+// OwnedRequest represents an List request.
+type OwnedRequest struct{}
+
+// Validate the request.
+func (r OwnedRequest) Validate() error {
+	return nil
+}
+
+// Owned clips.
+func (s *Service) Owned() ([]models.Group, error) {
+	var response []models.Group
+	err := s.Call(
+		&core.JSONRequest{Request: &OwnedRequest{}, Path: "/users/groups/owned"},
+		&response,
+	)
+
+	return response, err
+}

--- a/services/users/groups/owned_test.go
+++ b/services/users/groups/owned_test.go
@@ -1,0 +1,43 @@
+package groups_test
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/yitsushi/go-misskey"
+	"github.com/yitsushi/go-misskey/services/users/groups"
+	"github.com/yitsushi/go-misskey/test"
+	"log"
+	"net/http"
+	"os"
+	"testing"
+)
+
+func TestService_Owned(t *testing.T) {
+	client := test.MakeMockClient(test.SimpleMockOptions{
+		Endpoint:     "/api/users/groups/owned",
+		RequestData:  &groups.OwnedRequest{},
+		ResponseFile: "owned.json",
+		StatusCode:   http.StatusOK,
+	})
+
+	resp, err := client.Users().Groups().Owned()
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Len(t, resp, 1)
+}
+
+func ExampleService_Owned() {
+	client := misskey.NewClient("https://slippy.xyz", os.Getenv("MISSKEY_TOKEN"))
+
+	resp, err := client.Users().Groups().Owned()
+	if err != nil {
+		log.Printf("[Users/Groups/Owned] %s", err)
+
+		return
+	}
+
+	for _, group := range resp {
+		log.Printf("[Users/Groups/Owned] %s", group.Name)
+	}
+}

--- a/services/users/groups/owned_test.go
+++ b/services/users/groups/owned_test.go
@@ -1,14 +1,15 @@
 package groups_test
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/yitsushi/go-misskey"
-	"github.com/yitsushi/go-misskey/services/users/groups"
-	"github.com/yitsushi/go-misskey/test"
 	"log"
 	"net/http"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/yitsushi/go-misskey"
+	"github.com/yitsushi/go-misskey/services/users/groups"
+	"github.com/yitsushi/go-misskey/test"
 )
 
 func TestService_Owned(t *testing.T) {

--- a/services/users/groups/service.go
+++ b/services/users/groups/service.go
@@ -1,0 +1,15 @@
+package groups
+
+import (
+	"github.com/yitsushi/go-misskey/core"
+)
+
+// Service is the base for all the endpoints on this service.
+type Service struct {
+	Call core.RequestHandlerFunc
+}
+
+// NewService creates a new Service instance.
+func NewService(requestHandler core.RequestHandlerFunc) *Service {
+	return &Service{Call: requestHandler}
+}

--- a/services/users/groups/show.go
+++ b/services/users/groups/show.go
@@ -1,0 +1,36 @@
+package groups
+
+import (
+	"github.com/yitsushi/go-misskey/core"
+	"github.com/yitsushi/go-misskey/models"
+)
+
+// ShowRequest represents an List request.
+type ShowRequest struct {
+	GroupID string `json:"groupId"`
+}
+
+// Validate the request.
+func (r ShowRequest) Validate() error {
+	if r.GroupID == "" {
+		return core.RequestValidationError{
+			Request: r,
+			Message: core.UndefinedRequiredField,
+			Field:   "GroupID",
+		}
+	}
+
+	return nil
+}
+
+// Show clips.
+func (s *Service) Show(groupID string) (models.Group, error) {
+	request := ShowRequest{GroupID: groupID}
+	response := models.Group{}
+	err := s.Call(
+		&core.JSONRequest{Request: &request, Path: "/users/groups/show"},
+		&response,
+	)
+
+	return response, err
+}

--- a/services/users/groups/show.go
+++ b/services/users/groups/show.go
@@ -5,7 +5,7 @@ import (
 	"github.com/yitsushi/go-misskey/models"
 )
 
-// ShowRequest represents an List request.
+// ShowRequest represents an Show request.
 type ShowRequest struct {
 	GroupID string `json:"groupId"`
 }
@@ -23,7 +23,7 @@ func (r ShowRequest) Validate() error {
 	return nil
 }
 
-// Show clips.
+// Show group.
 func (s *Service) Show(groupID string) (models.Group, error) {
 	request := ShowRequest{GroupID: groupID}
 	response := models.Group{}

--- a/services/users/groups/show_test.go
+++ b/services/users/groups/show_test.go
@@ -1,0 +1,55 @@
+package groups_test
+
+import (
+	"log"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/yitsushi/go-misskey"
+	"github.com/yitsushi/go-misskey/core"
+	"github.com/yitsushi/go-misskey/services/users/groups"
+	"github.com/yitsushi/go-misskey/test"
+)
+
+func TestService_Show(t *testing.T) {
+	client := test.MakeMockClient(test.SimpleMockOptions{
+		Endpoint:     "/api/users/groups/show",
+		RequestData:  &groups.ShowRequest{},
+		ResponseFile: "show.json",
+		StatusCode:   http.StatusOK,
+	})
+
+	group, err := client.Users().Groups().Show("93tyd132e7")
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Equal(t, "Test", group.Name)
+}
+
+func TestShowRequest_Validate(t *testing.T) {
+	test.ValidateRequests(
+		t,
+		[]core.BaseRequest{
+			groups.ShowRequest{},
+		},
+		[]core.BaseRequest{
+			groups.ShowRequest{GroupID: "93tyd132e7"},
+		},
+	)
+}
+
+func ExampleService_Show() {
+	client := misskey.NewClient("https://slippy.xyz", os.Getenv("MISSKEY_TOKEN"))
+
+	group, err := client.Users().Groups().Show("93tyd132e7")
+	if err != nil {
+		log.Printf("[Users/Groups/Show] %s", err)
+
+		return
+	}
+
+	log.Printf("[Users/Groups/Show] %s", group.Name)
+}

--- a/services/users/groups/transfer.go
+++ b/services/users/groups/transfer.go
@@ -1,0 +1,45 @@
+package groups
+
+import (
+	"github.com/yitsushi/go-misskey/core"
+	"github.com/yitsushi/go-misskey/models"
+)
+
+// TransferRequest represents an Transfer request.
+type TransferRequest struct {
+	GroupID string `json:"groupId"`
+	UserID  string `json:"userId"`
+}
+
+// Validate the request.
+func (r TransferRequest) Validate() error {
+	if r.GroupID == "" {
+		return core.RequestValidationError{
+			Request: r,
+			Message: core.UndefinedRequiredField,
+			Field:   "GroupID",
+		}
+	}
+
+	if r.UserID == "" {
+		return core.RequestValidationError{
+			Request: r,
+			Message: core.UndefinedRequiredField,
+			Field:   "UserID",
+		}
+	}
+
+	return nil
+}
+
+// Transfer group.
+func (s *Service) Transfer(groupID, userID string) (models.Group, error) {
+	request := TransferRequest{GroupID: groupID, UserID: userID}
+	response := models.Group{}
+	err := s.Call(
+		&core.JSONRequest{Request: &request, Path: "/users/groups/transfer"},
+		&response,
+	)
+
+	return response, err
+}

--- a/services/users/groups/transfer_test.go
+++ b/services/users/groups/transfer_test.go
@@ -1,0 +1,57 @@
+package groups_test
+
+import (
+	"log"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/yitsushi/go-misskey"
+	"github.com/yitsushi/go-misskey/core"
+	"github.com/yitsushi/go-misskey/services/users/groups"
+	"github.com/yitsushi/go-misskey/test"
+)
+
+func TestService_Transfer(t *testing.T) {
+	client := test.MakeMockClient(test.SimpleMockOptions{
+		Endpoint:     "/api/users/groups/transfer",
+		RequestData:  &groups.TransferRequest{},
+		ResponseFile: "show.json",
+		StatusCode:   http.StatusOK,
+	})
+
+	group, err := client.Users().Groups().Transfer("93tyd132e7", "83sv4lyx22")
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Equal(t, "Test", group.Name)
+}
+
+func TestTransferRequest_Validate(t *testing.T) {
+	test.ValidateRequests(
+		t,
+		[]core.BaseRequest{
+			groups.TransferRequest{},
+			groups.TransferRequest{GroupID: "93tyd132e7"},
+			groups.TransferRequest{UserID: "93tyd132e7"},
+		},
+		[]core.BaseRequest{
+			groups.TransferRequest{GroupID: "93tyd132e7", UserID: "83sv4lyx22"},
+		},
+	)
+}
+
+func ExampleService_Transfer() {
+	client := misskey.NewClient("https://slippy.xyz", os.Getenv("MISSKEY_TOKEN"))
+
+	group, err := client.Users().Groups().Transfer("93tyd132e7", "83sv4lyx22")
+	if err != nil {
+		log.Printf("[Users/Groups/Transfer] %s", err)
+
+		return
+	}
+
+	log.Printf("[Users/Groups/Transfer] %s", group.Name)
+}

--- a/services/users/groups/update.go
+++ b/services/users/groups/update.go
@@ -1,0 +1,45 @@
+package groups
+
+import (
+	"github.com/yitsushi/go-misskey/core"
+	"github.com/yitsushi/go-misskey/models"
+)
+
+// UpdateRequest represents an Update request.
+type UpdateRequest struct {
+	GroupID string `json:"groupId"`
+	Name    string `json:"name"`
+}
+
+// Validate the request.
+func (r UpdateRequest) Validate() error {
+	if r.GroupID == "" {
+		return core.RequestValidationError{
+			Request: r,
+			Message: core.UndefinedRequiredField,
+			Field:   "GroupID",
+		}
+	}
+
+	if r.Name == "" {
+		return core.RequestValidationError{
+			Request: r,
+			Message: core.UndefinedRequiredField,
+			Field:   "Name",
+		}
+	}
+
+	return nil
+}
+
+// Update group.
+func (s *Service) Update(groupID, name string) (models.Group, error) {
+	request := UpdateRequest{GroupID: groupID, Name: name}
+	response := models.Group{}
+	err := s.Call(
+		&core.JSONRequest{Request: &request, Path: "/users/groups/update"},
+		&response,
+	)
+
+	return response, err
+}

--- a/services/users/groups/update_test.go
+++ b/services/users/groups/update_test.go
@@ -1,0 +1,57 @@
+package groups_test
+
+import (
+	"log"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/yitsushi/go-misskey"
+	"github.com/yitsushi/go-misskey/core"
+	"github.com/yitsushi/go-misskey/services/users/groups"
+	"github.com/yitsushi/go-misskey/test"
+)
+
+func TestService_Update(t *testing.T) {
+	client := test.MakeMockClient(test.SimpleMockOptions{
+		Endpoint:     "/api/users/groups/update",
+		RequestData:  &groups.UpdateRequest{},
+		ResponseFile: "show.json",
+		StatusCode:   http.StatusOK,
+	})
+
+	group, err := client.Users().Groups().Update("93tyd132e7", "New Name")
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Equal(t, "Test", group.Name)
+}
+
+func TestUpdateRequest_Validate(t *testing.T) {
+	test.ValidateRequests(
+		t,
+		[]core.BaseRequest{
+			groups.UpdateRequest{},
+			groups.UpdateRequest{GroupID: "93tyd132e7"},
+			groups.UpdateRequest{Name: "new name"},
+		},
+		[]core.BaseRequest{
+			groups.UpdateRequest{GroupID: "93tyd132e7", Name: "new name"},
+		},
+	)
+}
+
+func ExampleService_Update() {
+	client := misskey.NewClient("https://slippy.xyz", os.Getenv("MISSKEY_TOKEN"))
+
+	group, err := client.Users().Groups().Update("93tyd132e7", "New Name")
+	if err != nil {
+		log.Printf("[Users/Groups/Update] %s", err)
+
+		return
+	}
+
+	log.Printf("[Users/Groups/Update] %s", group.Name)
+}

--- a/services/users/service.go
+++ b/services/users/service.go
@@ -1,0 +1,21 @@
+package users
+
+import (
+	"github.com/yitsushi/go-misskey/core"
+	"github.com/yitsushi/go-misskey/services/users/groups"
+)
+
+// Service is the base for all the endpoints on this service.
+type Service struct {
+	Call core.RequestHandlerFunc
+}
+
+// NewService creates a new Service instance.
+func NewService(requestHandler core.RequestHandlerFunc) *Service {
+	return &Service{Call: requestHandler}
+}
+
+// Groups contains all endpoints under /users/groups.
+func (s *Service) Groups() *groups.Service {
+	return groups.NewService(s.Call)
+}


### PR DESCRIPTION
Related to #17 

### TODO

- [x] /users/groups/create
- [x] /users/groups/delete
- [x] /users/groups/invitations/accept
- [x] /users/groups/invitations/reject
- [x] /users/groups/invite
- [x] /users/groups/joined
- [x] /users/groups/leave
- [x] /users/groups/owned
- [x] /users/groups/pull
- [x] /users/groups/show
- [x] /users/groups/transfer
- [x] /users/groups/update
- [x] i/user-group-invites


#### How to get `invitationId`?

Required to use `users/groups/invitations/accept` and `users/groups/invitations/reject`)

Answer: `i/user-group-invites`

#### What does the users/groups/pull endpoint do?

Answer: Kick user :rofl: 
