### PR TITLE
fix: lack of parameters in Admin/Emoji/Add endpoint

### DIFF
--- a/services/admin/emoji/add.go
+++ b/services/admin/emoji/add.go
@@ -6,11 +6,19 @@ import (
 
 // AddRequest represents an Add request.
 type AddRequest struct {
+	Name   string `json:"name"`
 	FileID string `json:"fileId"`
 }
 
 // Validate the request.
 func (r AddRequest) Validate() error {
+	if r.Name == "" {
+		return core.RequestValidationError{
+			Request: r,
+			Message: core.UndefinedRequiredField,
+			Field:   "Name",
+		}
+	}
 	if r.FileID == "" {
 		return core.RequestValidationError{
 			Request: r,

--- a/services/admin/emoji/add.go
+++ b/services/admin/emoji/add.go
@@ -19,6 +19,7 @@ func (r AddRequest) Validate() error {
 			Field:   "Name",
 		}
 	}
+
 	if r.FileID == "" {
 		return core.RequestValidationError{
 			Request: r,

--- a/services/admin/emoji/add_test.go
+++ b/services/admin/emoji/add_test.go
@@ -22,6 +22,7 @@ func TestService_Add(t *testing.T) {
 	})
 
 	response, err := client.Admin().Emoji().Add(emoji.AddRequest{
+		Name:   "Test",
 		FileID: "8fbtx0k2ok",
 	})
 
@@ -37,10 +38,15 @@ func TestAddRequest_Validate(t *testing.T) {
 		t,
 		[]core.BaseRequest{
 			emoji.AddRequest{},
+			emoji.AddRequest{Name: ""},
 			emoji.AddRequest{FileID: ""},
+			emoji.AddRequest{Name: "", FileID: ""},
 		},
 		[]core.BaseRequest{
-			emoji.AddRequest{FileID: "asd"},
+			emoji.AddRequest{
+				Name:   "test",
+				FileID: "8fbtx0k2ok",
+			},
 		},
 	)
 }
@@ -49,6 +55,7 @@ func ExampleService_Add() {
 	client, _ := misskey.NewClientWithOptions(misskey.WithSimpleConfig("https://slippy.xyz", os.Getenv("MISSKEY_TOKEN")))
 
 	emojiID, err := client.Admin().Emoji().Add(emoji.AddRequest{
+		Name:   "EmojiName",
 		FileID: "8fbtx0k2ok",
 	})
 	if err != nil {


### PR DESCRIPTION
# Emoji API Adheres to Obsolete Specifications

### Description of the Change
- Added a 'Name' field to the Admin/Emoji/Add endpoint. 
- Introduced error handling for the 'Name' field.
 
### Issue or RFC
#97 Emoji API Adheres to Obsolete Specifications

### Possible Drawbacks
none

### Verification Process
I have created a DiscordBot using this library.

### Release Notes
- fix: lack of parameters in Admin/Emoji/Add endpoint