### PR TITLE
fix: Add omitempty to multipartField

### DIFF
--- a/core/multipart.go
+++ b/core/multipart.go
@@ -8,10 +8,11 @@ import (
 const numberOfPartsKeyValue = 2
 
 type multipartField struct {
-	Type  string
-	Name  string
-	Value []byte
-	Ref   string
+	Type      string
+	Name      string
+	Value     []byte
+	Ref       string
+	OmitEmpty bool
 }
 
 func parseMultipartFields(r BaseRequest) map[string]multipartField {
@@ -29,6 +30,9 @@ func parseMultipartFields(r BaseRequest) map[string]multipartField {
 		}
 
 		field := parseTag(tag)
+		if field.OmitEmpty && v.Field(i).IsZero() {
+			continue
+		}
 		if field.Name == "" {
 			field.Name = v.Type().Field(i).Name
 		}
@@ -46,7 +50,11 @@ func parseTag(tag string) multipartField {
 
 	for _, part := range strings.Split(tag, ",") {
 		if !strings.Contains(part, "=") {
-			field.Name = part
+			if part == "omitempty" {
+				field.OmitEmpty = true
+			} else {
+				field.Name = part
+			}
 
 			continue
 		}

--- a/core/multipart.go
+++ b/core/multipart.go
@@ -33,6 +33,7 @@ func parseMultipartFields(r BaseRequest) map[string]multipartField {
 		if field.OmitEmpty && v.Field(i).IsZero() {
 			continue
 		}
+
 		if field.Name == "" {
 			field.Name = v.Type().Field(i).Name
 		}

--- a/docs/patterns-and-structure.md
+++ b/docs/patterns-and-structure.md
@@ -39,7 +39,7 @@ Example multipart request struct:
 ```go
 // CreateRequest represents a request to create a file.
 type CreateRequest struct {
-	FolderID    string `multipart:"folderId,type=field"`
+	FolderID    string `multipart:"folderId,type=field,omitempty"`
 	Name        string `multipart:"name,type=field"`
 	IsSensitive bool   `multipart:"isSensitive,type=field"`
 	Force       bool   `multipart:"force,type=field"`

--- a/services/drive/files/create.go
+++ b/services/drive/files/create.go
@@ -7,7 +7,7 @@ import (
 
 // CreateRequest represents a request to create a file.
 type CreateRequest struct {
-	FolderID    string `multipart:"folderId,type=field"`
+	FolderID    string `multipart:"folderId,type=field,omitempty"`
 	Name        string `multipart:"name,type=field"`
 	IsSensitive bool   `multipart:"isSensitive,type=field"`
 	Force       bool   `multipart:"force,type=field"`


### PR DESCRIPTION
### Description of the Change

* Add OmitEmpty field to multipartField struct.
* Add "omitempty" tag to FolderID field of CreateRequest struct in drive/files.

### Issue or RFC

folderId in drive/files/create is optional.
related to #95 

### Alternate Designs

none

### Possible Drawbacks

none

### Verification Process

I uploaded both images with and without folder-id set.
If I set folder-id, then an image was uploaded to the specified folder.
If I set folder-id empty, then an image was uploaded to the root folder.

### Release Notes

* Add omitempty to multipartField
