### PR TITLE
feat: Implement Users.ReportAbuse

### DIFF
--- a/services/users/report_abuse.go
+++ b/services/users/report_abuse.go
@@ -1,0 +1,45 @@
+package users
+
+import (
+	"github.com/yitsushi/go-misskey/core"
+)
+
+// ReportAbuseRequest represents a ReportAbuse request.
+type ReportAbuseRequest struct {
+	UserID  string `json:"userId"`  // required
+	Comment string `json:"comment"` // required
+}
+
+// Validate the request.
+func (r ReportAbuseRequest) Validate() error {
+	if r.UserID == "" {
+		return core.RequestValidationError{
+			Request: r,
+			Message: core.UndefinedRequiredField,
+			Field:   "UserID",
+		}
+	}
+
+	if r.Comment == "" {
+		return core.RequestValidationError{
+			Request: r,
+			Message: core.UndefinedRequiredField,
+			Field:   "Comment",
+		}
+	}
+
+	return nil
+}
+
+// ReportAbuse is used to file a report.
+// It requires authentication.
+func (s *Service) ReportAbuse(userID string, comment string) error {
+	request := ReportAbuseRequest{UserID: userID, Comment: comment}
+
+	err := s.Call(
+		&core.JSONRequest{Request: &request, Path: "/users/report-abuse"},
+		&core.EmptyResponse{},
+	)
+
+	return err
+}

--- a/services/users/report_abuse_test.go
+++ b/services/users/report_abuse_test.go
@@ -1,0 +1,53 @@
+package users_test
+
+import (
+	"log"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/yitsushi/go-misskey"
+	"github.com/yitsushi/go-misskey/core"
+	"github.com/yitsushi/go-misskey/services/users"
+	"github.com/yitsushi/go-misskey/test"
+)
+
+func TestReportAbuseRequest_Validate(t *testing.T) {
+	test.ValidateRequests(
+		t,
+		[]core.BaseRequest{
+			users.ReportAbuseRequest{},
+			users.ReportAbuseRequest{Comment: "A comment without a user-id."},
+			users.ReportAbuseRequest{UserID: "8y1nj3wzmz"},
+		},
+		[]core.BaseRequest{
+			users.ReportAbuseRequest{UserID: "8gf082lv8f", Comment: "A comment with a user-id."},
+		},
+	)
+}
+
+func TestService_ReportAbuse(t *testing.T) {
+	client := test.MakeMockClient(test.SimpleMockOptions{
+		Endpoint:     "/api/users/report-abuse",
+		RequestData:  &users.ReportAbuseRequest{},
+		ResponseFile: "empty",
+		StatusCode:   http.StatusNoContent,
+	})
+
+	err := client.Users().ReportAbuse("88v9vu5nbu", "A comment.")
+
+	assert.NoError(t, err)
+}
+
+// ExampleService_ReportAbuse is an example of how to use the ReportAbuse method to file a report.
+func ExampleService_ReportAbuse() {
+	client, _ := misskey.NewClientWithOptions(misskey.WithSimpleConfig("https://slippy.xyz", os.Getenv("MISSKEY_TOKEN")))
+
+	err := client.Users().ReportAbuse("88v9vu5nbu", "A comment.")
+	if err != nil {
+		log.Printf("[Users/ReportAbuse] %s", err)
+
+		return
+	}
+}


### PR DESCRIPTION
### Description of the Change

API endpoint: /api/users/report-abuse
API Doc: https://misskey.io/api-doc#tag/users/operation/users/report-abuse
This endpoint requires a userId and a comment. It responds with 204 and empty payload on success. Alternately it returns a 4xx error.

### Issue or RFC

#17 Users ReportAbuse

### Alternate Designs

### Possible Drawbacks

### Verification Process

A unit test of the function and the request validation.
An example and tested it.

### Release Notes

- Can file reports against users.