### PR TITLE
feat: Implement Admin/Instance/ServerInfo

### DIFF
--- a/models/instance.go
+++ b/models/instance.go
@@ -29,3 +29,25 @@ type Instance struct {
 	IsSuspended             bool   `json:"isSuspended"`
 	OpenRegistrations       bool   `json:"openRegistrations"`
 }
+
+// ServerInfo has server information about a single instance.
+type ServerInfo struct {
+	Machine string `json:"machine"`
+	OS      string `json:"os"`
+	Node    string `json:"node"`
+	PSQL    string `json:"psql"`
+	CPU     struct {
+		Model string  `json:"model"`
+		Cores float64 `json:"cores"`
+	} `json:"cpu"`
+	Mem struct {
+		Total float64 `json:"total"`
+	} `json:"mem"`
+	FS struct {
+		Total float64 `json:"total"`
+		Used  float64 `json:"used"`
+	} `json:"fs"`
+	Net struct {
+		Interface string `json:"interface"`
+	} `json:"net"`
+}

--- a/services/admin/instance/fixtures/server-info.json
+++ b/services/admin/instance/fixtures/server-info.json
@@ -1,0 +1,20 @@
+{
+   "machine": "string",
+   "os": "linux",
+   "node": "20.2.0",
+   "psql": "string",
+   "cpu": {
+     "model": "arm64",
+     "cores": 20
+   },
+   "mem": {
+     "total": 5254
+   },
+   "fs": {
+     "total": 654,
+     "used": 3
+   },
+   "net": {
+     "interface": "eth0"
+   }
+ }

--- a/services/admin/instance/server_info.go
+++ b/services/admin/instance/server_info.go
@@ -1,0 +1,25 @@
+package instance
+
+import (
+	"github.com/yitsushi/go-misskey/core"
+	"github.com/yitsushi/go-misskey/models"
+)
+
+// ServerInfoRequest represents a Clear request.
+type ServerInfoRequest struct{}
+
+// Validate the request.
+func (r ServerInfoRequest) Validate() error {
+	return nil
+}
+
+// ServerInfo gets the server info.
+func (s *Service) ServerInfo() (models.ServerInfo, error) {
+	var response models.ServerInfo
+	err := s.Call(
+		&core.JSONRequest{Request: &ServerInfoRequest{}, Path: "/admin/server-info"},
+		&response,
+	)
+
+	return response, err
+}

--- a/services/admin/instance/server_info_test.go
+++ b/services/admin/instance/server_info_test.go
@@ -1,0 +1,53 @@
+package instance_test
+
+import (
+	"log"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/yitsushi/go-misskey"
+	"github.com/yitsushi/go-misskey/services/admin/instance"
+	"github.com/yitsushi/go-misskey/test"
+)
+
+func TestService_ServerInfo(t *testing.T) {
+	client := test.MakeMockClient(test.SimpleMockOptions{
+		Endpoint:     "/api/admin/server-info",
+		RequestData:  &instance.ServerInfoRequest{},
+		ResponseFile: "server-info.json",
+		StatusCode:   http.StatusOK,
+	})
+
+	response, err := client.Admin().Instance().ServerInfo()
+
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Equal(t, "string", response.Machine, "machine")
+	assert.Equal(t, "linux", response.OS, "os")
+	assert.Equal(t, "20.2.0", response.Node, "node")
+	assert.Equal(t, "string", response.PSQL, "psql")
+	assert.EqualValues(t, 20, response.CPU.Cores, "cpu.cores")
+	assert.EqualValues(t, "arm64", response.CPU.Model, "cpu.model")
+	assert.EqualValues(t, 5254, response.Mem.Total, "mem.total")
+	assert.EqualValues(t, 654, response.FS.Total, "fs.total")
+	assert.EqualValues(t, 3, response.FS.Used, "fs.used")
+	assert.EqualValues(t, "eth0", response.Net.Interface, "net.interface")
+}
+
+// ExampleService_ServerInfo demonstrates how to use Admin.Instance.ServerInfo.
+func ExampleService_ServerInfo() {
+	client, _ := misskey.NewClientWithOptions(misskey.WithSimpleConfig("https://slippy.xyz", os.Getenv("MISSKEY_TOKEN")))
+
+	response, err := client.Admin().Instance().ServerInfo()
+	if err != nil {
+		log.Printf("[Admin/Instance/ServerInfo] %s", err)
+
+		return
+	}
+
+	log.Printf("Server Info: %v", response)
+}

--- a/services/admin/instance/service.go
+++ b/services/admin/instance/service.go
@@ -1,0 +1,15 @@
+package instance
+
+import (
+	"github.com/yitsushi/go-misskey/core"
+)
+
+// Service is the base for all the endpoints on this service.
+type Service struct {
+	Call core.RequestHandlerFunc
+}
+
+// NewService creates a new Service instance.
+func NewService(requestHandler core.RequestHandlerFunc) *Service {
+	return &Service{Call: requestHandler}
+}

--- a/services/admin/service.go
+++ b/services/admin/service.go
@@ -6,6 +6,7 @@ import (
 	"github.com/yitsushi/go-misskey/services/admin/drive"
 	"github.com/yitsushi/go-misskey/services/admin/emoji"
 	"github.com/yitsushi/go-misskey/services/admin/federation"
+	"github.com/yitsushi/go-misskey/services/admin/instance"
 	"github.com/yitsushi/go-misskey/services/admin/logs"
 	"github.com/yitsushi/go-misskey/services/admin/moderation"
 	"github.com/yitsushi/go-misskey/services/admin/moderators"
@@ -78,4 +79,9 @@ func (s *Service) Relays() *relays.Service {
 // Promo contains all endpoints for promos.
 func (s *Service) Promo() *promo.Service {
 	return promo.NewService(s.Call)
+}
+
+// Instance contains all endpoints for info about the instance.
+func (s *Service) Instance() *instance.Service {
+	return instance.NewService(s.Call)
 }


### PR DESCRIPTION
### Description of the Change

admin/server-info

### Issue or RFC

#56 admin/server-info

https://misskey.io/api-doc#tag/admin/server-info

### Alternate Designs

### Possible Drawbacks

Only moderators can use this endpoint. Not clear how to document this but we will see ROLE_PERMISSION_DENIED error if we try without the permission.

### Verification Process

Created 

### Release Notes

- The admin/server-info endpoint is available for Admin/Instance/ServerInfo.
