### PR TITLE
feat: Add localOnly to Note model

### DIFF
--- a/models/note.go
+++ b/models/note.go
@@ -29,4 +29,5 @@ type Note struct {
 	URL          string            `json:"url"`
 	Instance     *Instance         `json:"instance"`
 	Poll         *Poll             `json:"poll"`
+	LocalOnly    bool              `json:"localOnly"`
 }

--- a/services/notes/timeline/fixtures/get.json
+++ b/services/notes/timeline/fixtures/get.json
@@ -174,6 +174,7 @@
         "text": "every day i strive to be cancelled by flowless not because i am being some variety of racist or otherwise gross,\n\nbut because i think the doritos locos taco from taco bell is, while a hideous parody of anything resembling mexican cuisine, actually pretty tasty and a yummy thing to put in my mouth and eat\n\nas is right and just.",
         "cw": null,
         "visibility": "public",
+        "localOnly": false,
         "renoteCount": 0,
         "repliesCount": 1,
         "reactions": {},

--- a/services/notes/timeline/get_test.go
+++ b/services/notes/timeline/get_test.go
@@ -32,6 +32,7 @@ func TestService_Get(t *testing.T) {
 
 	assert.Len(t, noteList, 3)
 	assert.Equal(t, "aoife", noteList[0].User.Username)
+	assert.Equal(t, false, noteList[0].LocalOnly)
 }
 
 func TestService_Get_withPoll(t *testing.T) {


### PR DESCRIPTION
### Requirements for Contributing

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

The Misskey API endpoint `notes/local-timeline` includes `localOnly` in the response.
Therefore, I add this to the `Note` model.

### Issue or RFC

<!--

Link to the issue that your change relates to. 

* An open issue without "invalid" label
* An open issue without "wontfix" label

To contribute an enhancement that doesn't statisfly
these conditions, please follow our guide:
https://github.com/yitsushi/go-misskey/blob/main/CONTRIBUTING.md#pull-requests

-->

### Alternate Designs

<!--

Explain what other alternates were considered and why the proposed version was selected.

-->

### Possible Drawbacks

<!--

What are the possible side-effects or negative impacts of the
code change?

-->

### Verification Process

<!--

What process did you follow to verify that the change has not
introduced any regressions? Describe the actions you performed,
and describe the results you observed.

Note: never post sensitive information like personal details,
      access tokens.

-->

I confirmed it with the following request.

```bash
$ curl -s 'https://slippy.xyz/api/notes/local-timeline' -H 'content-type: application/json' --data-raw '{"withFiles":false,"withRenotes":false,"withReplies":true,"excludeNsfw":true,"limit":10,"i":null}' | jq '.[].localOnly'
false
false
false
false
false
false
false
```

### Release Notes

<!--

Please describe the changes in a single line that explains this
improvement in terms that a user can understand. This text will be
used in release notes.

Examples:

- All endpoints are available for Lists.
- Easier to write tests with the new FooBar helper.

-->

- Add localOnly to Note model.