### PR TITLE
Fix timeline GetRequest to omit empty SinceID and UntilID

### DIFF
--- a/services/notes/timeline/get.go
+++ b/services/notes/timeline/get.go
@@ -8,8 +8,8 @@ import (
 // GetRequest represents an Get request.
 type GetRequest struct {
 	Limit                 uint   `json:"limit"`
-	SinceID               string `json:"sinceId"`
-	UntilID               string `json:"untilId"`
+	SinceID               string `json:"sinceId,omitempty"`
+	UntilID               string `json:"untilId,omitempty"`
 	SinceDate             uint64 `json:"sinceDate"`
 	UntilDate             uint64 `json:"untilDate"`
 	IncludeMyRenotes      bool   `json:"includeMyRenotes"`


### PR DESCRIPTION

### Description of the Change

Making `SinceID` and `UntilID` optional in `timeline.GetRequest`

### Issue or RFC

related #95 

### Verification Process

Send a `timeline.Get` request without setting `SinceID` and `UntilID`, observe you no longer receive the invalid parameter error.

### Release Notes

`timeline.Get` properly omits `SinceID` and `UntilID` when not specifying them in the request model.